### PR TITLE
Fix remaining use of deprecated set-output command

### DIFF
--- a/setup-containers.sh
+++ b/setup-containers.sh
@@ -12,7 +12,7 @@ for ((i=1; i<=$container_count; i++)); do
   containers+=($i);
 done
 
-# Format bash array as JSON array: https://stackoverflow.com/a/26809318/7651928
-containers_json=$(for f in "${containers[@]}"; do printf '%s' "$f" | jq -R -s .; done | jq -s .)
+# Format bash array as JSON array: https://stackoverflow.com/a/67489301
+containers_json=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${containers[@]}")
 
-echo ::set-output name=containers::$containers_json
+echo "containers=$containers_json" >> $GITHUB_OUTPUT


### PR DESCRIPTION
I missed this one script still using `set-output` from my last PR.
